### PR TITLE
Bugfix, i2c-dependency and ID mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function RGB(hardware, callback) {
   self._initialize(function(err) {
     if (self.failCallback(err, callback)) {
       setImmediate(function() {
-        this.emit('error', err);
+        self.emit('error', err);
       }.bind(this));
       return;
     }

--- a/index.js
+++ b/index.js
@@ -96,7 +96,8 @@ RGB.prototype._initialize = function(callback) {
 
   self._read8Bits(TCS34725_ID, function(err, id) {
 //    if (id.readUInt8(0) != MODULE_ID) {
-    if (id != MODULE_ID) {
+    // disabled, got different IDs depending on bus?
+    if (false && id != MODULE_ID) {
       var err = new Error("Unable to read ID off module. It may not be connected properly");
       return self.failCallback(err, callback);
     }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/sorokine/rgb-tcs34725/issues"
   },
   "dependencies": {
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "i2c": "^0.2.1"
   }
 }


### PR DESCRIPTION
I've had problems using it out of the box:
- this vs self typo in error handling
- i2c missed as a dependency

Also, but that might be somehow special:
- The given ID was not correct. And as I used two sensors on two i2c-buses I got even different IDs back.
- Therefor I overwrote the ID-check, but not sure if that's a common issue
